### PR TITLE
新增代码扫描规则 

### DIFF
--- a/src/main/java/org/sonar/samples/java/RulesList.java
+++ b/src/main/java/org/sonar/samples/java/RulesList.java
@@ -32,6 +32,7 @@ import org.sonar.samples.java.checks.DontUseErrorObjectRule;
 import org.sonar.samples.java.checks.DontUseErrorValueRule;
 import org.sonar.samples.java.checks.DontUseTotalDataRule;
 import org.sonar.samples.java.checks.GalaxyUndocumentedApiRule;
+import org.sonar.samples.java.checks.CollectionAndMapNullValueRule;
 import org.sonar.samples.java.checks.DcitsUndocumentedApiContainAuthorRule;
 import org.sonar.samples.java.checks.GalaxyUndocumentedApiContainAuthorRule;
 
@@ -61,6 +62,7 @@ public final class RulesList {
       .add(DcitsUndocumentedApiContainAuthorRule.class)
       .add(GalaxyUndocumentedApiContainAuthorRule.class)
       .add(GalaxySpringBeanAvoidNonFinalVariablesRule.class)
+      .add(CollectionAndMapNullValueRule.class)
       .build();
   }
 

--- a/src/main/java/org/sonar/samples/java/checks/CollectionAndMapNullValueRule.java
+++ b/src/main/java/org/sonar/samples/java/checks/CollectionAndMapNullValueRule.java
@@ -1,0 +1,58 @@
+package org.sonar.samples.java.checks;
+
+import org.sonar.check.Rule;
+import org.sonar.plugins.java.api.JavaFileScanner;
+import org.sonar.plugins.java.api.JavaFileScannerContext;
+import org.sonar.plugins.java.api.semantic.Symbol;
+import org.sonar.plugins.java.api.tree.BaseTreeVisitor;
+import org.sonar.plugins.java.api.tree.MemberSelectExpressionTree;
+import org.sonar.plugins.java.api.tree.MethodInvocationTree;
+import org.sonar.plugins.java.api.tree.Tree.Kind;
+
+/**
+ * <p/>
+ * <p/>
+ * 功能描述
+ * <p/>
+ * 规则：从集合或者map取值后 要做非空判断 如 list.get(0).toString() 存在空指针风险
+ * <p/>
+ * 
+ * @author zhangzhengp
+ *
+ */
+@Rule(key = "CollectionAndMapNullValue")
+public class CollectionAndMapNullValueRule extends BaseTreeVisitor implements JavaFileScanner {
+	private JavaFileScannerContext context;
+
+	@Override
+	public void scanFile(JavaFileScannerContext context) {
+		this.context = context;
+		scan(context.getTree());
+	}
+
+	@Override
+	public void visitMethodInvocation(MethodInvocationTree tree) {
+		Symbol symbol = tree.symbol();
+		if (symbol.isMethodSymbol()) {
+			String methodName = symbol.name();
+			if ("toString".equals(methodName) || "equals".equals(methodName)) {
+				if (tree.methodSelect().is(Kind.MEMBER_SELECT)) {
+					MemberSelectExpressionTree expressionTree = (MemberSelectExpressionTree) tree.methodSelect();
+					if (expressionTree.expression().is(Kind.METHOD_INVOCATION)) {
+						MethodInvocationTree beforeTree = (MethodInvocationTree) expressionTree.expression();
+						Symbol beforeSymbol = beforeTree.symbol();
+						if (beforeSymbol.isMethodSymbol()) {
+							String beforeMethodName = beforeSymbol.name();
+							String beforeOwner = beforeSymbol.owner().name().toLowerCase();
+							if ("get".equals(beforeMethodName)
+									&& (beforeOwner.endsWith("map") || beforeOwner.endsWith("list"))) {
+								context.reportIssue(this, tree, "空指针隐患");
+							}
+						}
+					}
+				}
+
+			}
+		}
+	}
+}

--- a/src/main/resources/org/sonar/l10n/java/rules/squid/CollectionAndMapNullValue_java.html
+++ b/src/main/resources/org/sonar/l10n/java/rules/squid/CollectionAndMapNullValue_java.html
@@ -1,0 +1,14 @@
+<p>空指针异常</p>
+<h2>Code Example</h2>
+<pre>
+从集合或者map取值后 要做非空判断连续调用，存在空指针风险
+例1
+			map.get(key).toString();
+			list.get(i).toString(); 
+			list.get(i).equals(map);
+</pre>
+<h2>Compliant Solution</h2>
+<pre>
+   为了避免空指针风险，建议对 map.get(key)和 list.get(i)做非空判断
+</pre>
+

--- a/src/main/resources/org/sonar/l10n/java/rules/squid/CollectionAndMapNullValue_java.json
+++ b/src/main/resources/org/sonar/l10n/java/rules/squid/CollectionAndMapNullValue_java.json
@@ -1,0 +1,13 @@
+{
+  "title": "java-空指针异常",
+  "type": "VULNERABILITY",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "5min"
+  },
+  "tags": [
+    "pitfall"
+  ],
+  "defaultSeverity": "Critical"
+}

--- a/src/test/files/CollectionAndMapNullValueCheck.java
+++ b/src/test/files/CollectionAndMapNullValueCheck.java
@@ -1,0 +1,13 @@
+import java.util.HashMap;
+import java.util.ArrayList;
+
+class CollectionAndMapNullValueCheck {
+	  public void test() {
+		  HashMap map = new HashMap<String,Object>();
+		  ArrayList list = new ArrayList<Object>();
+		    map.get("key");// Compliant
+			map.get("key").toString(); // Noncompliant {{空指针隐患}}
+			list.get(0).toString(); // Noncompliant {{空指针隐患}}
+			list.get(0).equals(map); // Noncompliant {{空指针隐患}}
+	    }
+}

--- a/src/test/java/org/sonar/samples/java/checks/CollectionAndMapNullValueCheckTest.java
+++ b/src/test/java/org/sonar/samples/java/checks/CollectionAndMapNullValueCheckTest.java
@@ -1,0 +1,33 @@
+/*
+ * SonarQube Java Custom Rules Example
+ * Copyright (C) 2016-2016 SonarSource SA
+ * mailto:contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.samples.java.checks;
+
+import org.junit.Test;
+import org.sonar.java.checks.verifier.JavaCheckVerifier;
+
+public class CollectionAndMapNullValueCheckTest {
+  @Test
+  public void detected() {
+    // Verifies that the check will raise the adequate issues with the expected message.
+    // In the test file, lines which should raise an issue have been commented out
+    // by using the following syntax: "// Noncompliant {{EXPECTED_MESSAGE}}"
+    JavaCheckVerifier.verify("src/test/files/CollectionAndMapNullValueCheck.java", new CollectionAndMapNullValueRule());
+  }
+}


### PR DESCRIPTION
检查集合取值后直接操作存在的空指针风险 ，如
```
			map.get("key").toString();
			map.get("key").equals("123"); 
			list.get(0).toString(); 
			list.get(0).equals(map);
```
